### PR TITLE
fail fast if ssm parameter does not exist

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -89,7 +89,7 @@ ssm_get_parameter() {
     #echo "--- :ssm: SSM value ${ssmValue}"
 
     # fail fast
-    if [[ $rc -eq 0 ]]; then
+    if [[ ! $rc -eq 0 ]]; then
         echo "Command failed: The parameter '/buildkite/$ssmkey' does not exist or another error occurred."
         exit 1
     fi

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -85,7 +85,14 @@ ssm_get_parameter() {
     local exportname="$3"
     echo "--- :ssm: Get SSM /buildkite/${ssmkey} in region ${awsregion}"
     ssmValue=$(aws ssm get-parameter --region "$awsregion" --name "/buildkite/$ssmkey" --with-decryption --query Parameter.Value --output text)
+    rc=$?
     #echo "--- :ssm: SSM value ${ssmValue}"
+
+    # fail fast
+    if [[ $rc -eq 0 ]]; then
+        echo "Command failed: The parameter '/buildkite/$ssmkey' does not exist or another error occurred."
+        exit 1
+    fi
 
     if [[ -n "${exportname:-}" ]]; then
         echo "Using custom export name specified ${exportname}"


### PR DESCRIPTION
Rather than exporting an empty envvar and scratching our heads :monkey:, fail fast with a clear error message.